### PR TITLE
Use async instantiateStreaming loading method 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,15 +62,17 @@ function createCompatibleModuleInBundle(transpiledJs, transpiledWasm) {
 
 function createCompatibleModuleOutBundle(publicPath) {
     return `
-        var f=fetch(${publicPath}).then(function(response){
-            return response.arrayBuffer();
-        }).then(function(binary){
-                var module = new WebAssembly.Module(binary);
-                var instance = new WebAssembly.Instance(module, { env: { abort: function() {} } });
-                return instance.exports;
-        });
-        module.exports =f;
-            `;
+        function createWebAssemblyModulePromise() {
+            var p = WebAssembly.instantiateStreaming(
+                fetch(${publicPath}),
+                { env: { abort: function() {} } }
+            ).then(function(module) {
+                return module.instance.exports;
+            });
+            return p;
+        }
+        module.exports = createWebAssemblyModulePromise;
+    `;
 }
 function mkDirsSync(dirname) {
     if (fs.existsSync(dirname)) {


### PR DESCRIPTION
### TL;DR
Refactors the `createCompatibleModuleOutBundle` function to return the more efficient and asynchronous streaming method to load WebAssembly modules in the browser,  [`WebAssembly.instantiateStreaming`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming). 

### Why?
Most browsers will not synchronously compile wasm modules that are greater than 4KB on the main thread. Therefore, this library doesn't work when using any larger assembly applications unless loaded inside a worker.

Both [Mozilla](https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running) and [Google](https://developers.google.com/web/updates/2018/04/loading-wasm) now advocate using the `WebAssembly. instantiateStreaming()` t compile and instantiate a modules directly from a streamed underlying source via `fetch()`.

### Notes

##### Interface:
Previously this function returned an `Promise` and not a `function` which returns a `Promise`, this differs between the inline variant which does return a promise generating function. Therefore, there wasn't consistency between to two return values. This is confusing for consumers as your documentation and examples in the readme assume that you must first invoke the returned function. 

Therefore, I have refactored this method to also return a Promise generating function for consistency in your API. However, due to this, it should probably be releases as a major version as it's a breaking change.

##### Tests:
The repo's tests are currently in a broken state in master when cloning the repository from scratch and installing dependencies with `yarn` or `npm`. Therefore, I haven't been able to validate if the tests pass after this change. Any help fixing the underlying issue with the dependencies would be greatly appreciated. See #9 for more detail.